### PR TITLE
Category Rework

### DIFF
--- a/beta_symbols.js
+++ b/beta_symbols.js
@@ -1,6 +1,7 @@
 import * as Util from "./util.js"
 import { Symbol } from "./symbol.js"
 
+/* This file contains symbols still in testing. They may be broken or unbalanced */
 
 export class FreeTurn extends Symbol {
     static name = '🎟️';

--- a/beta_symbols.js
+++ b/beta_symbols.js
@@ -1,0 +1,57 @@
+import * as Util from "./util.js"
+import { Symbol } from "./symbol.js"
+
+
+export class FreeTurn extends Symbol {
+    static name = '🎟️';
+    constructor() {
+        super();
+        this.rarity = 0.03;
+    }
+    copy() { return new FreeTurn(); }
+    async evaluate(game, x, y) {
+        if (chance(game, 0.1, x, y)) {
+            await Util.animate(game.board.getSymbolDiv(x, y), 'flip', 0.15, 3);
+            game.inventory.turns++;
+            game.inventory.updateUi();
+            await game.board.removeSymbol(game, x, y);
+        }
+    }
+    description() {
+        return '10% chance: one more ⏰, then disappears'
+    }
+    descriptionLong() {
+        return 'this is a free turn ticket. it has a 10% chance to give you one more ⏰. if it succeeded, it disappears from your inventory.';
+    }
+}
+
+
+export class Grave extends Symbol {
+    static name = '🪦';
+    constructor() {
+        super();
+        this.rarity = 0.06;
+    }
+    copy() { return new Grave(); }
+    async evaluateProduce(game, x, y) {
+        const coords = game.board.nextToEmpty(x, y);
+        if (coords.length === 0) {
+            return;
+        }
+        if (game.inventory.graveyard.length === 0) {
+            return;
+        }
+        if (chance(game, 0.1, x, y)) {
+            const [newX, newY] = Util.randomRemove(coords);
+            const oldSymbol = Util.randomChoose(game.inventory.graveyard).copy();
+            await Util.animate(game.board.getSymbolDiv(x, y), 'bounce', 0.15, 2);
+            await game.board.addSymbol(game, oldSymbol, newX, newY);
+        }
+    }
+    description() {
+        return '10% chance: adds random symbol removed this game';
+    }
+    descriptionLong() {
+        return 'this is a grave. it has a 10% chance to add a previously removed symbol to a nearby empty space';
+    }
+}

--- a/board.js
+++ b/board.js
@@ -250,4 +250,12 @@ export class Board {
     return this.nextToExpr(x, y, (sym) => ["⬜", "🕳️"].includes(sym.name()));
   };
 
+
+  nextToCategory(x, y, category_name) {
+    const category_symbols = this.catalog.categories.get(category_name)
+    if (!category_symbols || category_symbols.length === 0) {
+      return [];
+    }
+    return this.nextToExpr(x, y, (sym) => category_symbols.includes(sym.name()));
+  }
 }

--- a/catalog.js
+++ b/catalog.js
@@ -5,6 +5,7 @@ export class Catalog {
     }
     async updateSymbols() {
         this.symbols = new Map();
+        this.categories = new Map();
         for (let source of this.symbolSources) {
             console.log(`processing ${source}...`); 
             try {
@@ -12,6 +13,14 @@ export class Catalog {
                 for (const [_, value] of Object.entries(symModule)) {
                     let sym = new value();
                     this.symbols.set(sym.name(), sym);
+                    let cats = sym.categories();
+                    if (cats.length > 0) {
+                        for (const cat of cats) {
+                            const old = this.categories.get(cat) || []
+                            old.push(sym.name());
+                            this.categories.set(cat, old)
+                        }
+                    }
                 }
             }
             catch(error) {

--- a/game_settings.js
+++ b/game_settings.js
@@ -1,9 +1,6 @@
 import * as Utils from "./util.js"
 
 export class GameSettings {
-
-    // TODO: temporary hack
-
     static loadFn;
 
     constructor() {
@@ -35,7 +32,7 @@ export class GameSettings {
         const symbolSourcesInput = Utils.createInput('Symbol Sources', 'textarea', this.symbolSources.join("\n"));
         const startingSymbolsInput = Utils.createInput('Starting Symbols', 'text', this.startingSet);
         // Create buttons
-        const cancelButton = Utils.createButton('Cancel', () => this.close());
+        const cancelButton = Utils.createButton('Cancel', async () => await this.close());
         const saveButton = Utils.createButton('Save', () => this.save(numRowsInput, numColumnsInput, symbolSourcesInput, startingSymbolsInput));
 
         // Append elements to the settings div

--- a/game_settings.js
+++ b/game_settings.js
@@ -24,6 +24,7 @@ export class GameSettings {
             return;
         }
         this.isOpen = true;
+        this.settingsDiv = document.querySelector('.game .settings');
         this.settingsDiv.replaceChildren();
 
         // Create input elements

--- a/symbol.js
+++ b/symbol.js
@@ -35,6 +35,9 @@ export class Symbol {
   async evaluateProduce() {}
   async finalScore(game, x, y) {}
   async score(game, x, y) {}
+  categories() {
+    return []
+  }
   description() {
     throw new Error('Trying to get description of base class.');
   }
@@ -258,6 +261,9 @@ export class Butter extends Symbol {
   counter() {
     return 7 - this.turns;
   }
+  categories() {
+    return ["Food"]
+  }
   description() {
     return 'x3 to neighboring 🍿<br>melts after 7 turns';
   }
@@ -284,8 +290,7 @@ export class Bug extends Symbol {
     this.foodScore = 0;
   }
   async evaluateConsume(game, x, y) {
-    const coords = game.board.nextToExpr(x, y, 
-      (sym) => Food.includes(sym.name()));
+    const coords = game.board.nextToCategory(x, y, "Food")
     if (coords.length === 0) {
       if (this.turns >= 5) {
         await game.board.removeSymbol(game, x, y);
@@ -381,6 +386,9 @@ export class Cherry extends Symbol {
       Util.animate(game.board.getSymbolDiv(x, y), 'flip', 0.15),
       this.addMoney(game, coords.length * 2, x, y)]);
   }
+  categories() {
+    return ["Fruits", "Food"]
+  }
   description() {
     return '💵2 for each neighboring 🍒';
   }
@@ -461,6 +469,9 @@ export class Clover extends Symbol {
     this.rarity = 0.21;
   }
   copy() { return new Clover(); }
+  categories() {
+    return ["Vegetables", "Food"]
+  }
   description() {
     return '+1% luck';
   }
@@ -557,6 +568,9 @@ export class Corn extends Symbol {
         await game.board.addSymbol(game, popcorn, newX, newY);
       }
     }
+  }
+  categories() {
+    return ["Vegetables", "Food"]
   }
   description() {
     return '💵20<br>10% chance: pops 🍿';
@@ -943,8 +957,7 @@ export class Mango extends Symbol {
   }
   copy() { return new Mango(); }
   async evaluateScore(game, x, y) {
-    const coords = game.board.nextToExpr(x, y,
-      (sym) => Fruits.includes(sym.name()));
+    const coords = game.board.nextToCategory(x, y, "Fruits");
     if (coords.length === 0) {
       return;
     }
@@ -953,6 +966,9 @@ export class Mango extends Symbol {
       const [neighborX, neighborY] = coord;
       game.board.cells[neighborY][neighborX].multiplier *= 2;
     }
+  }
+  categories() {
+    return ["Fruits", "Food"]
   }
   description() {
     return 'x2 to neighboring fruit';
@@ -1097,6 +1113,9 @@ export class Pineapple extends Symbol {
       Util.animate(game.board.getSymbolDiv(x, y), 'bounce', 0.1),
       this.addMoney(game, 12 - coords.length * 2, x, y)]);
   }
+  categories() {
+    return ["Fruits", "Food"]
+  }
   description() {
     return '💵12<br>💵-2 for all non-empty neighbors';
   }
@@ -1130,6 +1149,9 @@ export class Popcorn extends Symbol {
   }
   counter(game) {
     return this.timeToLive - this.turns;
+  }
+  categories() {
+    return ["Food"]
   }
   description() {
     return '💵17<br>disappears after 2-5 turns'
@@ -1387,7 +1409,3 @@ export class Worker extends Symbol {
     return 'this is a worker. it pays 💵3 for each neighboring 🪨 removed. it has a 50% chance to produce 💎 in place of the destroyed 🪨.';
   }
 }
-
-const Fruits = [Cherry, Mango, Pineapple].map(f => f.name);
-const Vegetables = [Corn, Clover].map(f => f.name);
-const Food = [...Fruits, ...Vegetables, Popcorn.name, Butter.name];

--- a/symbol.js
+++ b/symbol.js
@@ -848,59 +848,6 @@ export class Fox extends Symbol {
   }
 }
 
-export class FreeTurn extends Symbol {
-  static name = '🎟️';
-  constructor() {
-    super();
-    this.rarity = 0.03;
-  }
-  copy() { return new FreeTurn(); }
-  async evaluate(game, x, y) {
-    if (chance(game, 0.1, x, y)) {
-      await Util.animate(game.board.getSymbolDiv(x, y), 'flip', 0.15, 3);
-      game.inventory.turns++;
-      game.inventory.updateUi();
-      await game.board.removeSymbol(game, x, y);
-    }
-  }
-  description() {
-    return '10% chance: one more ⏰, then disappears'
-  }
-  descriptionLong() {
-    return 'this is a free turn ticket. it has a 10% chance to give you one more ⏰. if it succeeded, it disappears from your inventory.';
-  }
-}
-
-export class Grave extends Symbol {
-  static name = '🪦';
-  constructor() {
-    super();
-    this.rarity = 0.06;
-  }
-  copy() { return new Grave(); }
-  async evaluateProduce(game, x, y) {
-    const coords = game.board.nextToEmpty(x, y);
-    if (coords.length === 0) {
-      return;
-    }
-    if (game.inventory.graveyard.length === 0) {
-      return;
-    }
-    if (chance(game, 0.1, x, y)) {
-      const [newX, newY] = Util.randomRemove(coords);
-      const oldSymbol = Util.randomChoose(game.inventory.graveyard).copy();
-      await Util.animate(game.board.getSymbolDiv(x, y), 'bounce', 0.15, 2);
-      await game.board.addSymbol(game, oldSymbol, newX, newY);
-    }
-  }
-  description() {
-    return '10% chance: adds random symbol removed this game';
-  }
-  descriptionLong() {
-    return 'this is a grave. it has a 10% chance to add a previously removed symbol to a nearby empty space';
-  }
-}
-
 export class Hole extends Symbol {
   static name = '🕳️';
   constructor() {


### PR DESCRIPTION
- Refactors "Categories" to be a property of the symbol:
```
categories() {
    return ["Fruits", "Food"]
  }
```
- Categories loaded at runtime to allow additional symbol files to add new symbols to existing categories etc.
- nextToCategory utility method on Board to make checking for categories simple in symbol code
- minor cleanup to hidden settings menu code
- Moves FreeTurn and Grave to `beta_symbols.js`